### PR TITLE
:nail_care: stop using null objects for speed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A markov generator of 2 depth and variable complexity. It's made to be really re
 
 ## Why should I care?
 
-It has a whopping **zero** deps. It's **blisteringly fast**, it's decently tested, written in typescript (javascript with type safety), and keeps its state as a simple simple, easily manipulatable object.
+It has a whopping **zero** deps. It's **blisteringly fast**, it's 100% tested, written in typescript (javascript with type safety), and keeps its state as a simple *simple*, easily manipulatable object.
 
 It's super small and powerful. Two months of tweets is parsed, saved to disk as a re-usable json state map, **and** turned into random 50 sentences in less than **50ms** in the following code snippet:
 
@@ -31,7 +31,7 @@ It's super small and powerful. Two months of tweets is parsed, saved to disk as 
   console.log(tweeter.sentence(50));
 ```
 
-It's also **fully tested to be hideously accurate**. When given Frankenstein, it outputs a distribution of characters _including punctuation_ less than 5% off of the input novel when outputting 50,000 words, [check out the test](https://github.com/one19/markov-json/blob/master/test/index_test.ts#L234)! This test [that would qualify for nanowrimo](https://nanowrimo.org/) is usually output in just under 3 seconds! [*(Check out what little was changed to make memoization happen and boost performance by double!)*](https://github.com/one19/markov-json/pull/6)
+It's also **fully tested to be hideously accurate**. When given Frankenstein, it outputs a distribution of characters *including punctuation* less than 5% off of the input novel when outputting 50,000 words, [check out the test](https://github.com/one19/markov-json/blob/master/test/index_test.ts#L234)! This test [that would qualify for nanowrimo](https://nanowrimo.org/) is usually output in just under 3 seconds! [*(Check out what little was changed to make memoization happen and boost performance by double!)*](https://github.com/one19/markov-json/pull/6)
 
 Other libs just can't live up.
 


### PR DESCRIPTION
null objects are complex, and with memoization and modern(ish) node versions, using them might not be worth it.

It's useful to create opposing pull requests to get a head-to-head of performance vs this one crazy change!

**Interesting!** In a [head](https://travis-ci.org/one19/markov-json/builds/398530813) to [head](https://travis-ci.org/one19/markov-json/builds/398532064) it seems like [null object instantiation](https://github.com/one19/markov-json/pull/7) is actually either **slower** or gives **no benefit**.


Since that trick is more confusing for js newbies, and also giving no benefit in the current system, as well as making the output object less useful to the end-user of the lib, this pr should win out!